### PR TITLE
Bump custom dump to 0.10.3

### DIFF
--- a/CustomDump.podspec
+++ b/CustomDump.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = "CustomDump"
-  spec.version = "0.6.1"
+  spec.version = "0.10.3"
   spec.summary = "A collection of tools for debugging, diffing, and testing your application's data structures."
   spec.description  = <<-DESC
   A collection of tools for debugging, diffing, and testing your application's data structures.

--- a/XCTestDynamicOverlay.podspec
+++ b/XCTestDynamicOverlay.podspec
@@ -2,9 +2,6 @@ Pod::Spec.new do |spec|
   spec.name         = "XCTestDynamicOverlay"
   spec.version      = "0.8.0"
   spec.summary      = "Define XCTest assertion helpers directly in your application and library code."
-  spec.description  = <<-DESC
-  Define XCTest assertion helpers directly in your application and library code.
-  DESC
   
   spec.homepage = "https://www.pointfree.co"
   spec.license = { :type => "MIT", :file => "xctest-dynamic-overlay/LICENSE" }
@@ -17,5 +14,5 @@ Pod::Spec.new do |spec|
   spec.swift_version = '5.5'
   
   spec.source = { :git => "https://github.com/pointfreeco/xctest-dynamic-overlay.git", :tag => "#{spec.version}" }
-  spec.source_files = "xctest-dynamic-overlay/Sources/**/*.swift"
+  spec.source_files = "Sources/**/*.swift"
 end


### PR DESCRIPTION
Version - updated
License, source - unchanged.
Dependency to "XCTestDynamicOverlay", "~> 0.4" - unchanged.